### PR TITLE
Clean up event ID elements in form

### DIFF
--- a/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
+++ b/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
@@ -114,7 +114,7 @@ export function CircularEditForm({
   defaultSubject,
   searchString,
   defaultCreatedOnDateTime,
-  defaultEventId,
+  defaultEventId: originalEventId,
   intent,
 }: {
   formattedContributor: string
@@ -140,16 +140,20 @@ export function CircularEditForm({
   const [submitter, setSubmitter] = useState(defaultSubmitter)
   const subjectValid = subjectIsValid(subject)
   const derivedEventId = parseEventFromSubject(subject)
-  const mismatched = defaultEventId != derivedEventId
-  const [linkEventId, setLinkEventId] = useState(mismatched ? false : true)
-  const placeholderEvent = linkEventId ? derivedEventId : defaultEventId
-  const [eventId, setEventId] = useState(placeholderEvent)
-  const eventIdValid = eventId ? derivedEventId === eventId : true
+  const [linkEventId, setLinkEventId] = useState(
+    originalEventId === derivedEventId
+  )
+  const [defaultEventId, setDefaultEventId] = useState(
+    originalEventId || derivedEventId
+  )
+  const [eventId, setEventId] = useState(defaultEventId)
+  const eventIdValid = Boolean(eventId)
   const submitterValid = circularId ? submitterIsValid(submitter) : true
   const bodyValid = bodyIsValid(body)
   const dateTimeValid = circularId ? dateTimeIsValid(dateTime) : true
   const sending = Boolean(useNavigation().formData)
-  const valid = subjectValid && bodyValid && dateTimeValid && submitterValid
+  const valid =
+    subjectValid && bodyValid && dateTimeValid && submitterValid && eventIdValid
   let headerText, saveButtonText
 
   switch (intent) {
@@ -173,7 +177,7 @@ export function CircularEditForm({
     format !== defaultFormat ||
     submitter?.trim() !== defaultSubmitter ||
     dateTime !== defaultCreatedOnDateTime ||
-    eventId?.trim() !== defaultEventId
+    eventId?.trim() !== originalEventId
 
   const userIsModerator = useModStatus()
 
@@ -265,6 +269,7 @@ export function CircularEditForm({
             required
             onChange={({ target: { value } }) => {
               setSubject(value)
+              setDefaultEventId(parseEventFromSubject(value))
             }}
           />
         </InputGroup>
@@ -277,37 +282,44 @@ export function CircularEditForm({
         </CollapsableInfo>
         {intent !== 'new' && (
           <>
-            <InputGroup
-              className={classnames('maxw-full', {
-                'usa-input--success': eventIdValid && !linkEventId,
-                'border-0': linkEventId,
-              })}
-            >
-              <InputPrefix className="wide-input-prefix">Event ID</InputPrefix>
-              <TextInput
-                className="maxw-full"
-                name="eventId"
-                id="eventId"
-                type="text"
-                readOnly={linkEventId}
-                value={eventId}
-                onChange={({ target: { value } }) => {
-                  setEventId(value)
-                }}
-              />
-            </InputGroup>
-
+            {linkEventId ? (
+              <InputGroup className="maxw-full usa-input---not-editable">
+                <InputPrefix className="wide-input-prefix">
+                  Event ID
+                </InputPrefix>
+                <span className="padding-1">{derivedEventId}</span>
+                <input type="hidden" name="eventId" value={eventId} />
+              </InputGroup>
+            ) : (
+              <InputGroup
+                className={classnames('maxw-full', {
+                  'usa-input--success': eventIdValid,
+                })}
+              >
+                <InputPrefix className="wide-input-prefix">
+                  Event ID
+                </InputPrefix>
+                <TextInput
+                  className="maxw-full"
+                  defaultValue={defaultEventId}
+                  name="eventId"
+                  id="eventId"
+                  type="text"
+                  onChange={({ target: { value } }) => {
+                    setEventId(value)
+                  }}
+                />
+              </InputGroup>
+            )}
             <Checkbox
               id="autofill-eventId"
               name="autofill-eventId"
               className="margin-bottom-2"
-              label="Autofill event ID from subject"
+              label="Automatically fill event ID from subject"
               checked={linkEventId}
-              onChange={() => {
-                linkEventId
-                  ? setEventId(defaultEventId)
-                  : setEventId(derivedEventId)
-                setLinkEventId(!linkEventId)
+              onChange={({ target: { checked } }) => {
+                setLinkEventId(checked)
+                if (checked) setEventId(defaultEventId)
               }}
             />
           </>

--- a/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
+++ b/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
@@ -152,8 +152,7 @@ export function CircularEditForm({
   const bodyValid = bodyIsValid(body)
   const dateTimeValid = circularId ? dateTimeIsValid(dateTime) : true
   const sending = Boolean(useNavigation().formData)
-  const valid =
-    subjectValid && bodyValid && dateTimeValid && submitterValid && eventIdValid
+  const valid = subjectValid && bodyValid && dateTimeValid && submitterValid
   let headerText, saveButtonText
 
   switch (intent) {

--- a/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
+++ b/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
@@ -147,7 +147,6 @@ export function CircularEditForm({
     originalEventId || derivedEventId
   )
   const [eventId, setEventId] = useState(defaultEventId)
-  const eventIdValid = Boolean(eventId)
   const submitterValid = circularId ? submitterIsValid(submitter) : true
   const bodyValid = bodyIsValid(body)
   const dateTimeValid = circularId ? dateTimeIsValid(dateTime) : true
@@ -290,11 +289,7 @@ export function CircularEditForm({
                 <input type="hidden" name="eventId" value={eventId} />
               </InputGroup>
             ) : (
-              <InputGroup
-                className={classnames('maxw-full', {
-                  'usa-input--success': eventIdValid,
-                })}
-              >
+              <InputGroup className="maxw-full">
                 <InputPrefix className="wide-input-prefix">
                   Event ID
                 </InputPrefix>

--- a/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
+++ b/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
@@ -309,11 +309,18 @@ export function CircularEditForm({
               id="autofill-eventId"
               name="autofill-eventId"
               className="margin-bottom-2"
-              label="Automatically fill event ID from subject"
+              label={
+                <>
+                  Automatically fill event ID from subject
+                  {eventId !== derivedEventId &&
+                    '. The event ID does not match.'}
+                </>
+              }
               checked={linkEventId}
               onChange={({ target: { checked } }) => {
                 setLinkEventId(checked)
-                if (checked) setEventId(defaultEventId)
+                setDefaultEventId(derivedEventId)
+                setEventId(derivedEventId)
               }}
             />
           </>


### PR DESCRIPTION
- Eliminate circular React data flows: an element should not have a value given by a state variable that it updates on change
- Spell `autofill` as `Automatically fill`